### PR TITLE
Fix overriding of global formatoptions

### DIFF
--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -58,7 +58,6 @@ setlocal smartindent
 " Linewidth to 79, because of the formatoptions this is only valid for
 " comments
 setlocal textwidth=79
-set formatoptions=qrocb
 
 setlocal nowrap     " Do not wrap lines automatically
 


### PR DESCRIPTION
Today it overrides global formatoptions every time we open php file.

I think better do not override at least global formatoptions.
