### PR TITLE
Checking the value of variables instead of if it exists.

### DIFF
--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -35,11 +35,21 @@ endfunction
 
 " {{{ Settings
 " First the global PHP configuration
-let php_sql_query=1 " to highlight SQL syntax in strings
-let php_html_in_strings=1 " to highlight HTML in string
-let php_noShortTags = 1 " to disable short tags
-let PHP_autoformatcomment = 1
-let php_sync_method = -1
+if (!exists('php_sql_query'))
+    let php_sql_query=1 " to highlight SQL syntax in strings
+endif
+if (!exists('php_html_in_strings'))
+    let php_html_in_strings=1 " to highlight HTML in string
+endif
+if (!exists('php_noShortTags'))
+    let php_noShortTags = 1 " to disable short tags
+endif
+if (!exists('php_autoformatcomment'))
+    let PHP_autoformatcomment = 1
+endif
+if (!exists('php_sync_method'))
+    let php_sync_method = -1
+endif
 if (!exists('php_folding'))
    let php_folding = 1  "to enable folding for classes and functions
 endif

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,12 +1,12 @@
 " File:        php.vim
 " Description: PHP Integration for VIM plugin
-" 			   This file is a considerable fork of the original 
+" 			   This file is a considerable fork of the original
 " 			   PDV written by Tobias Schlitt <toby@php.net>.
 " Maintainer:  Steve Francia <piv@spf13.com> <http://spf13.com>
 " Version:     0.9
 " Last Change: 7th January 2012
-" 
-" 
+"
+"
 " Section: script init stuff {{{1
 if exists("loaded_piv")
     finish
@@ -36,8 +36,8 @@ endfunction
 " {{{ Settings
 " First the global PHP configuration
 let php_sql_query=1 " to highlight SQL syntax in strings
-let php_htmlInStrings=1 " to highlight HTML in string
-let php_noShortTags = 1 " to disable short tags 
+let php_html_in_strings=1 " to highlight HTML in string
+let php_noShortTags = 1 " to disable short tags
 let PHP_autoformatcomment = 1
 let php_sync_method = -1
 if (!exists('php_folding'))
@@ -152,15 +152,15 @@ func! PhpAlign() range
 			continue
 		endif
 		" \{-\} matches ungreed *
-        let l:index = substitute (getline (l:line), '^\s*\(.\{-\}\)\s*\S\{0,1}=\S\{0,1\}\s.*$', '\1', "") 
+        let l:index = substitute (getline (l:line), '^\s*\(.\{-\}\)\s*\S\{0,1}=\S\{0,1\}\s.*$', '\1', "")
         let l:indexlength = strlen (l:index)
         let l:maxlength = l:indexlength > l:maxlength ? l:indexlength : l:maxlength
         let l:line = l:line + 1
     endwhile
-    
+
 	let l:line = a:firstline
 	let l:format = "%s%-" . l:maxlength . "s %s %s"
-    
+
 	while l:line <= l:endline
 		if getline (l:line) =~ '^\s*\/\/.*$'
 			let l:line = l:line + 1
@@ -178,7 +178,7 @@ func! PhpAlign() range
     let &g:paste = l:paste
 endfunc
 
-" }}}   
+" }}}
 
 function! s:CreateNMap(target, combo)
     if !hasmapto(a:target, 'n')

--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -2,7 +2,7 @@
 " Language: PHP 5.3 & up
 " Maintainer: Paul Garvin <paul@paulgarvin.net>
 " Last Change:  April 2, 2010
-" URL: 
+" URL:
 "
 " Former Maintainer:  Peter Hodge <toomuchphp-vim@yahoo.com>
 " Former URL: http://www.vim.org/scripts/script.php?script_id=1571
@@ -65,7 +65,7 @@ unlet! b:current_syntax
 syntax spell default
 
 " Set sync method if none declared
-if !exists("php_sync_method")
+if (!exists("php_sync_method") || php_sync_method==1)
   if exists("php_minlines")
     let php_sync_method=php_minlines
   else
@@ -80,16 +80,16 @@ syn sync clear
 unlet! b:current_syntax
 syn cluster sqlTop remove=sqlString,sqlComment
 
-if exists("php_sql_query")
+if (!exists("php_sql_query") || php_sql_query==1)
   syn cluster phpAddStrings contains=@sqlTop
 endif
 
-if exists("php_html_in_strings")
+if (!exists("php_html_in_strings") || php_html_in_strings==1)
   syn cluster phpAddStrings add=@htmlTop
 endif
 
 syn case match
- 
+
 " Superglobals
 syn keyword phpSuperglobals GLOBALS _GET _POST _REQUEST _FILES _COOKIE _SERVER _SESSION _ENV HTTP_RAW_POST_DATA php_errormsg http_response_header argc argv contained
 


### PR DESCRIPTION
Instead of checking if a variable exists, check the value. This will allow it to be overwritten, which currently does not happen if ftplugin/php.vim runs (it just hardcodes php_sql_query to on).
