### PR TITLE
Remove visual wrap methods

### DIFF
--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -126,18 +126,6 @@ if g:PIVAutoClose
 endif
 " }}} Automatic close char mapping
 
-
-" {{{ Wrap visual selections with chars
-
-vnoremap <buffer> ( "zdi(<C-R>z)<ESC>
-vnoremap <buffer> { "zdi{<C-R>z}<ESC>
-vnoremap <buffer> [ "zdi[<C-R>z]<ESC>
-vnoremap <buffer> ' "zdi'<C-R>z'<ESC>
-" Removed in favor of register addressing
-" :vnoremap " "zdi"<C-R>z"<ESC>
-
-" }}} Wrap visual selections with chars
-
 " {{{ Dictionary completion
 setlocal dictionary-=$VIMRUNTIME/bundle/PIV/misc/funclist.txt dictionary+=$VIMRUNTIME/bundle/PIV/misc/funclist.txt
 


### PR DESCRIPTION
Some of these mappings break built-in navigation functionality (e.g. {
and ( in visual mode).  Additionally, this type of functionality isn't
really PHP specific and is thus better achieved through a plugin like
tpope's vim-surround.
